### PR TITLE
Update Dashboard.scala

### DIFF
--- a/src/main/scala/metl/comet/Dashboard.scala
+++ b/src/main/scala/metl/comet/Dashboard.scala
@@ -169,7 +169,7 @@ class Dashboard extends CometActor with CometListener with CheckRenderHelper {
     case s: CheckResult if Globals.currentUserAccessRestriction.permit(s) =>
       partialUpdate(jsCmdCreator(CheckAction.Update, s))
     case UserLoggedIn(s: LiftSession) if S.session.exists(_ == s) =>
-      S.redirectTo("/")
+      S.redirectTo("/simple")
     case CreateCheck(check)
         if Globals.currentUserAccessRestriction.permit(check) =>
       partialUpdate(


### PR DESCRIPTION
Setting the default login page to /simple so that the standard experience is clearer.